### PR TITLE
Remove defines

### DIFF
--- a/_mkdocs/docs/guides/02-persistent-storage.md
+++ b/_mkdocs/docs/guides/02-persistent-storage.md
@@ -42,7 +42,6 @@ Let's extend `database.yaml` with a `volume` definition:
         defines: runnable
         inherits: mongodb/latest
         volumes:
-            defines: volumes
             important-data:
                 size: 60
                 kind: SSD
@@ -64,7 +63,6 @@ Since we have the volume defined, now it's time to mount it inside the container
         defines: runnable
         inherits: mongodb/latest
         volumes:
-            defines: volumes
             important-data:
                 size: 60
                 kind: SSD
@@ -77,7 +75,6 @@ We have just replaced the `${monk-volume-path}/mongodb` because `database` inher
 
         ```yaml linenums="1"
         containers:
-            defines: containers
             database:
                 image: mongo:latest
                 ports: 27017:27017
@@ -97,7 +94,6 @@ This means it is sufficient to just provide the `volume-data` in the `volumes` s
         defines: runnable
         inherits: mongodb/latest
         volumes:
-            defines: volumes
             important-data:
                 size: 60
                 kind: SSD

--- a/_mkdocs/docs/guides/04-config-files.md
+++ b/_mkdocs/docs/guides/04-config-files.md
@@ -12,21 +12,18 @@ Let's take an nginx Kit as an example an analyze how nginx configuration is pass
         defines: runnable
 
         containers:
-            defines: containers
             nginx-reverse-proxy:
                 image-tag: latest
                 ports: <- `0.0.0.0:${listen-port}:${listen-port}/tcp`
                 image: bitnami/nginx
 
         variables:
-            defines: variables
             server-name: www.example.com
             listen-port: 8080
             proxy-target-host: google.com
             proxy-target-port: 80
 
         files:
-            defines: files
             server-def:
                 container: nginx-reverse-proxy
                 path: /opt/bitnami/nginx/conf/server_blocks/reverse_proxy.conf

--- a/_mkdocs/docs/guides/05-affinity.md
+++ b/_mkdocs/docs/guides/05-affinity.md
@@ -20,7 +20,6 @@ Let's define a basic Kit:
     foo:
         defines: runnable
         containers:
-            defines: containers
             utils:
                 image: amouat/network-utils
                 image-tag: latest
@@ -44,7 +43,6 @@ Let's extend the Kit by adding `affinity` section:
         defines: runnable
         inherits: guide/foo
         affinity:
-            defines: affinity
             name: <<name of one of your nodes>> # <----
     ```
 
@@ -78,7 +76,6 @@ Let's create another Kit with a different `affinity` section:
         defines: runnable
         inherits: guide/foo
         affinity:
-            defines: affinity
             tag: <<your tag>> # <----
     ```
 
@@ -120,7 +117,6 @@ Then, let's copy the Kit from Step 2 and make a subtle change:
         defines: runnable
         inherits: guide/foo
         affinity:
-            defines: affinity
             name: <<name of one of your nodes>> # <---- use the same name as in Step 2
             resident: true                      # <---- add this
     ```

--- a/_mkdocs/docs/guides/basic-app.md
+++ b/_mkdocs/docs/guides/basic-app.md
@@ -75,7 +75,6 @@ Let's start writing a Kit that will describe where to get the app, how to config
         defines: runnable
         version: 0.0.1
         containers:
-            defines: containers
             app:
                 image: yourname/tutorial:latest
     ```
@@ -122,7 +121,6 @@ First, let's define the variables in our `runnable`. Add the following `variable
     app:
         # ...
         variables:
-            defines: variables
             port:
                 type: int
                 value: 8080
@@ -166,7 +164,6 @@ Your `app.yaml` manifest should now look like this:
         defines: runnable
         version: 0.0.1
         containers:
-            defines: containers
             app:
                 image: yourname/tutorial:latest
                 ports:
@@ -176,7 +173,6 @@ Your `app.yaml` manifest should now look like this:
                     - <- `DB_HOST=${db-host}`
                     - <- `DB_PORT=${db-port}`
         variables:
-            defines: variables
             port:
                 type: int
                 value: 8080

--- a/_mkdocs/docs/guides/connecting-runnables.md
+++ b/_mkdocs/docs/guides/connecting-runnables.md
@@ -14,7 +14,6 @@ Consider the following Kit:
     my-service:
         defines: runnable
         containers:
-            defines: containers
             my-service:
                 image: ubuntu:latest
                 environment:
@@ -22,7 +21,6 @@ Consider the following Kit:
                     - <- `DB_PORT=${db-port}`
                 bash: echo "db at ${DB_ADDR}:${DB_PORT}" ; sleep 3600
         variables:
-            defines: variables
             db-addr:
                 type: string
                 value: localhost
@@ -65,7 +63,6 @@ The Kit should now look like this:
     my-service:
         defines: runnable
         containers:
-            defines: containers
             my-service:
                 image: ubuntu:latest
                 environment:
@@ -73,7 +70,6 @@ The Kit should now look like this:
                     - <- `DB_PORT=${db-port}`
                 bash: echo "db at ${DB_ADDR}:${DB_PORT}" ; sleep 3600
         variables:
-            defines: variables
             db-addr:
                 type: string
                 value: <- get-hostname("mongodb/latest", "database")

--- a/_mkdocs/docs/guides/hooks.md
+++ b/_mkdocs/docs/guides/hooks.md
@@ -14,7 +14,6 @@ This is a very basic example of how a hook can be applied to generate a file ins
     foo:
         defines: runnable
         containers:
-            defines: containers
             bar:
                 image: alpine:latest
                 entrypoint: <- `/bin/sh /root/r.sh`
@@ -22,14 +21,12 @@ This is a very basic example of how a hook can be applied to generate a file ins
                     container-started: hello-world
 
         files:
-            defines: files
             r1:
                 path: /root/r.sh
                 container: bar
                 contents: "while true; do sleep 1; date; done"
 
         actions:
-            defines: actions
             hello-world:
                 code: exec("bar", "/bin/sh", "-c", `echo "Hello World" > /tmp/hello`)
     ```

--- a/_mkdocs/docs/guides/k8s-configmaps-and-secrets.md
+++ b/_mkdocs/docs/guides/k8s-configmaps-and-secrets.md
@@ -31,7 +31,6 @@ namespace: /nginx
 server:
   defines: runnable
   containers:
-    defines: containers
     nginx:
       image-tag: latest
       image: nginx
@@ -47,7 +46,6 @@ namespace: /nginx
 server:
   defines: runnable
   containers:
-    defines: containers
     nginx:
       image-tag: latest
       image: nginx
@@ -55,7 +53,6 @@ server:
           - 80:80
 
   files:
-    defines: files
     gameprop:
       container: nginx
       path: /usr/share/nginx/html/game.properties
@@ -94,7 +91,6 @@ namespace: /nginx
 server:
   defines: runnable
   containers:
-    defines: containers
     nginx:
       image-tag: latest
       image: nginx
@@ -105,7 +101,6 @@ server:
         - <- `PORT=${runningPort}`
 
   files:
-    defines: files
     gameprop:
       container: nginx
       path: /usr/share/nginx/html/game.properties
@@ -122,7 +117,6 @@ server:
         how.nice.to.look=fairlyNice
 
   variables:
-    defines: variables
     username:
       type: string
       value: anonymous
@@ -165,7 +159,6 @@ namespace: /nginx
 server:
   defines: runnable
   containers:
-    defines: containers
     nginx:
       image-tag: latest
       image: nginx
@@ -177,7 +170,6 @@ server:
         - <- `PASSWORD=${password}`
 
   files:
-    defines: files
     gameprop:
       container: nginx
       path: /usr/share/nginx/html/game.properties
@@ -194,7 +186,6 @@ server:
         how.nice.to.look=fairlyNice
 
   variables:
-    defines: variables
     username:
       type: string
       value: anonymous

--- a/_mkdocs/docs/guides/k8s-migrate.md
+++ b/_mkdocs/docs/guides/k8s-migrate.md
@@ -73,7 +73,6 @@ We need something similar in Monk to run the application component. Lets define 
     ui:
         defines: runnable
         containers:
-            defines: containers
             yelb-ui:
                 image-tag: "0.7"
                 image: mreferre/yelb-ui
@@ -125,7 +124,6 @@ Again, we will look at containers spec, and produce similar YAML:
     appserver:
         defines: runnable
         containers:
-            defines: containers
             yelb-appserver:
                 image-tag: "0.5"
                 image: mreferre/yelb-appserver
@@ -171,7 +169,6 @@ Again, we'll reference the containers spec and produce similar YAML:
     db:
         defines: runnable
         containers:
-            defines: containers
             yelb-db:
                 image-tag: "0.5"
                 image: mreferre/yelb-db
@@ -217,7 +214,6 @@ Referencing the contianer spec, we'll write similar YAML:
     redis:
         defines: runnable
         containers:
-            defines: containers
             redis-server:
                 image-tag: "4.0.2"
                 image: redis
@@ -397,7 +393,6 @@ We can see that `Service` listens and redirects requests to port 80. Lets amend 
     ui:
     defines: runnable
     containers:
-        defines: containers
         yelb-ui:
         image-tag: "0.7"
         image: mreferre/yelb-ui
@@ -486,7 +481,6 @@ Lets combine all the information into our YAML file:
     ui:
     defines: runnable
     containers:
-        defines: containers
         yelb-ui:
         image-tag: "0.7"
         image: mreferre/yelb-ui
@@ -496,7 +490,6 @@ Lets combine all the information into our YAML file:
             /startup.sh`
 
     variables:
-        defines: variables
         port: 80
         yelb-appserver-addr:
         type: string
@@ -594,7 +587,6 @@ Our YAML should look like:
     appserver:
         defines: runnable
         containers:
-            defines: containers
             yelb-appserver:
                 image-tag: "0.5"
                 image: mreferre/yelb-appserver
@@ -604,7 +596,6 @@ Our YAML should look like:
                     /startup.sh`
 
         variables:
-            defines: variables
             port: 4567
             yelb-db-addr:
                 type: string
@@ -777,14 +768,12 @@ Our `appserver` definition will look like that:
         # We are inheriting main runnable yelb/appserver
         inherits: yelb/appserver
         containers:
-            defines: containers
             # We will overwrite our image-tag here, all other definition of the runnable will stay the same
             yelb-appserver:
                 image-tag: "0.4"
 
         # Update the namespace in our variables, changing it from yelb to yelb-production
         variables:
-            defines: variables
             yelb-db-addr:
                 type: string
                 value: <- get-hostname("yelb-production/db", "yelb-db")
@@ -805,7 +794,6 @@ Finally, we will look at UI, which will be less problematic. For that, we'll jus
         inherits: yelb/ui
 
         variables:
-            defines: variables
             # Update our appserver hostname here with production version
             yelb-appserver-addr:
                 type: string
@@ -831,12 +819,10 @@ The final YAML should look like this:
         defines: runnable
         inherits: yelb/appserver
         containers:
-            defines: containers
             yelb-appserver:
                 image-tag: "0.4"
 
         variables:
-            defines: variables
             yelb-db-addr:
                 type: string
                 value: <- get-hostname("yelb-production/db", "yelb-db")
@@ -850,7 +836,6 @@ The final YAML should look like this:
         inherits: yelb/ui
 
         variables:
-            defines: variables
             yelb-appserver-addr:
                 type: string
                 value: <- get-hostname("yelb-production/appserver", "yelb-appserver")

--- a/_mkdocs/docs/guides/load-balancers.md
+++ b/_mkdocs/docs/guides/load-balancers.md
@@ -21,14 +21,12 @@ service-1:
     defines: runnable
     inherits: nginx/latest
     variables:
-        defines: variables
         listen-port: 8080
 
 service-2:
     defines: runnable
     inherits: nginx/latest
     variables:
-        defines: variables
         listen-port: 8080
 
 services:
@@ -55,7 +53,6 @@ services:
     defines: process-group
 
     balancers:
-        defines: balancers
         app-balancer:
             type: http
             port: 8080
@@ -85,7 +82,6 @@ services:
     defines: process-group
 
     balancers:
-        defines: balancers
         app-balancer:
             type: http
             domain: mystuff.com
@@ -132,7 +128,6 @@ A TCP and UDP load balancers can be used to balance TCP and UDP connections over
         defines: process-group
 
         balancers:
-            defines: balancers
             app-balancer:
                 type: tcp
                 port: 8080
@@ -154,7 +149,6 @@ A TCP and UDP load balancers can be used to balance TCP and UDP connections over
         defines: process-group
 
         balancers:
-            defines: balancers
             app-balancer:
                 type: udp
                 port: 8080
@@ -182,7 +176,6 @@ services:
     defines: process-group
 
     balancers:
-        defines: balancers
         app-balancer:
             type: elastic-ip
             instances:
@@ -209,7 +202,6 @@ services:
     defines: process-group
 
     balancers:
-        defines: balancers
         app-balancer:
             port: 8080
             type: http
@@ -239,7 +231,6 @@ services:
     defines: process-group
 
     balancers:
-        defines: balancers
         app-balancer:
             port: 8080
             type: http

--- a/_mkdocs/docs/guides/passing-secrets.md
+++ b/_mkdocs/docs/guides/passing-secrets.md
@@ -56,7 +56,6 @@ Let's suppose we have the following Kit:
     my-service:
         defines: runnable
         containers:
-            defines: containers
             foo:
                 image: foo:latest
                 environment:

--- a/_mkdocs/docs/guides/provisioning-via-templates.md
+++ b/_mkdocs/docs/guides/provisioning-via-templates.md
@@ -21,7 +21,6 @@ foo:
     defines: runnable
 
     nodes:
-        defines: nodes
         my-node:
             provider: gcp
             tag: my-magical-cluster
@@ -30,11 +29,9 @@ foo:
             disk-size: 128
 
     affinity:
-        defines: affinity
         name: my-node
 
     containers:
-        defines: containers
         some-service:
             image: some/image
             image-tag: latest

--- a/_mkdocs/docs/guides/readiness-and-dependency-checks.md
+++ b/_mkdocs/docs/guides/readiness-and-dependency-checks.md
@@ -39,7 +39,6 @@ namespace: readiness
 
 common:
     containers:
-        defines: containers
         fooc:
             image: alpine
             image-tag: latest
@@ -49,7 +48,6 @@ bar:
     defines: runnable
     inherits: ./common
     checks:
-        defines: checks
         readiness:
             code: |
                 exec("fooc", "ps", "-ef") "sleep" contains?
@@ -71,7 +69,6 @@ Lets have a look at full definition of dependency checks:
 
 ```yaml
 depends:
-    defines: depends
     wait-for:
         runnables:
             - <a runnable path to wait for>
@@ -88,7 +85,6 @@ namespace: readiness
 
 common:
     containers:
-        defines: containers
         foo:
             image: alpine
             image-tag: latest
@@ -99,7 +95,6 @@ bar:
     inherits: ./common
 
     checks:
-        defines: checks
         readiness:
             code: |
                 exec("foo", "ps", "-ef") contains?("sleep")
@@ -112,7 +107,6 @@ baz:
     inherits: ./common
 
     depends:
-        defines: depends
         wait-for:
             runnables:
                 - ./bar
@@ -129,7 +123,6 @@ We've added here our simple dependency using:
 
 ```yaml
 depends:
-    defines: depends
     wait-for:
         runnables:
             - ./bar

--- a/_mkdocs/docs/monkscript/scripting-index.md
+++ b/_mkdocs/docs/monkscript/scripting-index.md
@@ -73,7 +73,6 @@ Will return `3` as long as it is placed within a [`runnable`](yaml/runnables.md)
 
 ```yaml
 variables:
-    defines: variables
     foo: 1
     bar: 2
 ```

--- a/_mkdocs/docs/monkscript/yaml/groups.md
+++ b/_mkdocs/docs/monkscript/yaml/groups.md
@@ -38,7 +38,6 @@ Runnable sections can have multiple sub-sections of special meaning. All definit
 
 ```yaml
 variables:
-    defines: variables
     variable-a: ...
     variable-b: ...
 ```
@@ -86,7 +85,6 @@ A variable can either just specify the value - in which case the type is inferre
 
 ```yaml
 variables:
-    defines: actions
     action-a: ...
     action-b: ...
 ```
@@ -134,7 +132,6 @@ Actions are somewhat akin to function definitions known from regular programming
 
 ```yaml linenums="1"
 actions:
-    defines: actions
 
     sum:
         description: sums two numbers
@@ -162,7 +159,6 @@ actions:
 
 ```yaml linenums="1"
 balancers:
-    defines: balancers
     balancer-a: ...
     balancer-b: ...
 ```

--- a/_mkdocs/docs/monkscript/yaml/index.md
+++ b/_mkdocs/docs/monkscript/yaml/index.md
@@ -100,12 +100,10 @@ Consider the following definitions:
 foo:
     defines: runnable
     containers:
-        defines: containers
         ...
 bar:
     defines: runnable
     fun-boxes:
-        defines: containers
 ```
 
 Both `foo` and `bar` are [`runnable`](#runnable). The key defines has special meaning, it labels its parent node with a _descriptor_ (in this case, `runnable`). Monk finds relevant sections by looking at those descriptors.

--- a/_mkdocs/docs/monkscript/yaml/runnables.md
+++ b/_mkdocs/docs/monkscript/yaml/runnables.md
@@ -11,7 +11,6 @@ Runnables are the most common and basic unit in Monk. They represent a container
         defines: runnable
 
         containers:
-            defines: containers
             utils:
                 image: amouat/network-utils
                 image-tag: latest
@@ -34,7 +33,6 @@ Runnable sections can have multiple sub-sections of special meaning. All definit
 
 ```yaml
 containers:
-    defines: containers
     container-a: ...
     container-b: ...
 ```
@@ -86,7 +84,6 @@ container-name:
 
 ```yaml
 variables:
-    defines: variables
     variable-a: ...
     variable-b: ...
 ```
@@ -132,7 +129,6 @@ A variable can either just specify the value - in which case the type is inferre
 
 ```yaml
 variables:
-    defines: actions
     action-a: ...
     action-b: ...
 ```
@@ -180,7 +176,6 @@ Actions are somewhat akin to function definitions known from regular programming
 
 ```yaml linenums="1"
 actions:
-    defines: actions
 
     sum:
         description: sums two numbers
@@ -208,7 +203,6 @@ actions:
 
 ```yaml linenums="1"
 files:
-    defines: files
     file-a: ...
     file-b: ...
 ```
@@ -252,7 +246,6 @@ It's useful to declare multiline file `contents` using YAML syntax `|`
 
 ```yaml linenums="1"
 files:
-    defines: files
     poem:
         path: /var/poem.txt
         container: dummy
@@ -272,7 +265,6 @@ Each runnable can contain status checks. Currently the only supported check is `
 
 ```yaml linenums="1"
 checks:
-    defines: checks
     readiness:
         code: exec("ethereum-node", "echo", "-e", "two") "two" contains?
         period: 15
@@ -288,7 +280,6 @@ This works by awaiting the results of [`readiness` `checks`](#checks) on all ref
 
 ```yaml linenums="1"
 depends:
-    defines: depends
     wait-for:
         runnables:
             - /some/another-runnable
@@ -311,7 +302,6 @@ If it doesn't exist, Monk will assume default values:
 
 ```yaml linenums="1"
 recovery:
-    defines: recovery
     after: 60s # timeout before start recovey mechanism
     when: always/node-failure/container-failure/none # condition when to start recovery
     # node-failure - recover only if node is failed
@@ -340,7 +330,6 @@ If `ignore-pressure` is `true` (`false` by default) Monk will ignore pressure an
 
 ```yaml linenums="1"
 affinity:
-    defines: affinity
     tag: test-node
     name: test
     ignore-pressure: false

--- a/_mkdocs/docs/monkscript/yaml/services.md
+++ b/_mkdocs/docs/monkscript/yaml/services.md
@@ -13,7 +13,6 @@ Services can be composed with other Services and Runnables to form [Groups](/mon
         defines: runnable
 
         containers:
-            defines: containers
             utils:
                 image: amouat/network-utils
                 image-tag: latest
@@ -36,7 +35,6 @@ Runnable sections can have multiple sub-sections of special meaning. All definit
 
 ```yaml
 containers:
-    defines: containers
     container-a: ...
     container-b: ...
 ```
@@ -88,7 +86,6 @@ container-name:
 
 ```yaml
 variables:
-    defines: variables
     variable-a: ...
     variable-b: ...
 ```
@@ -134,7 +131,6 @@ A variable can either just specify the value - in which case the type is inferre
 
 ```yaml
 variables:
-    defines: actions
     action-a: ...
     action-b: ...
 ```
@@ -182,7 +178,6 @@ Actions are somewhat akin to function definitions known from regular programming
 
 ```yaml linenums="1"
 actions:
-    defines: actions
 
     sum:
         description: sums two numbers

--- a/_mkdocs/docs/templates/02-volumes-1.yaml
+++ b/_mkdocs/docs/templates/02-volumes-1.yaml
@@ -4,7 +4,6 @@ database:
   defines: runnable
   inherits: mongodb/latest
   volumes:
-    defines: volumes
     important-data:
       kind: 60
       type: SSD

--- a/docs/affinity.md
+++ b/docs/affinity.md
@@ -22,7 +22,6 @@ namespace: guide
 foo:
     defines: runnable
     containers:
-        defines: containers
         utils:
             image: amouat/network-utils
             image-tag: latest
@@ -44,7 +43,6 @@ foo-on-node:
     defines: runnable
     inherits: guide/foo
     affinity:
-        defines: affinity
         name: <<name of one of your nodes>> # <----
 ```
 
@@ -76,7 +74,6 @@ foo-on-tag:
     defines: runnable
     inherits: guide/foo
     affinity:
-        defines: affinity
         tag: <<your tag>> # <----
 ```
 
@@ -116,7 +113,6 @@ foo-on-node-resident:
     defines: runnable
     inherits: guide/foo
     affinity:
-        defines: affinity
         name: <<name of one of your nodes>> # <---- use the same name as in Step 2
         resident: true                      # <---- add this
 ```

--- a/docs/basic-app.md
+++ b/docs/basic-app.md
@@ -76,7 +76,6 @@ app:
     defines: runnable
     version: 0.0.1
     containers:
-        defines: containers
         app:
             image: yourname/tutorial:latest
 ```
@@ -123,7 +122,6 @@ namespace: /yourname
 app:
     # ...
     variables:
-        defines: variables
         port:
             type: int
             value: 8080
@@ -165,7 +163,6 @@ app:
     defines: runnable
     version: 0.0.1
     containers:
-        defines: containers
         app:
             image: yourname/tutorial:latest
             ports:
@@ -175,7 +172,6 @@ app:
                 - <- `DB_HOST=${db-host}`
                 - <- `DB_PORT=${db-port}`
     variables:
-        defines: variables
         port:
             type: int
             value: 8080

--- a/docs/config-files.md
+++ b/docs/config-files.md
@@ -14,21 +14,18 @@ reverse-proxy:
     defines: runnable
 
     containers:
-        defines: containers
         nginx-reverse-proxy:
             image-tag: latest
             ports: <- `0.0.0.0:${listen-port}:${listen-port}/tcp`
             image: bitnami/nginx
 
     variables:
-        defines: variables
         server-name: www.example.com
         listen-port: 8080
         proxy-target-host: google.com
         proxy-target-port: 80
 
     files:
-        defines: files
         server-def:
             container: nginx-reverse-proxy
             path: /opt/bitnami/nginx/conf/server_blocks/reverse_proxy.conf

--- a/docs/connecting-runnables.md
+++ b/docs/connecting-runnables.md
@@ -16,7 +16,6 @@ namespace: mystuff
 my-service:
     defines: runnable
     containers:
-        defines: containers
         my-service:
             image: ubuntu:latest
             environment:
@@ -25,7 +24,6 @@ my-service:
             bash: <- `echo db at $DB_ADDR:$DB_PORT ; sleep 3600`
 
     variables:
-        defines: variables
         db-addr:
             type: string
             value: localhost
@@ -65,7 +63,6 @@ namespace: mystuff
 my-service:
     defines: runnable
     containers:
-        defines: containers
         my-service:
             image: ubuntu:latest
             environment:
@@ -73,7 +70,6 @@ my-service:
                 - <- `DB_PORT=${db-port}`
             bash: <- `echo db at $DB_ADDR:$DB_PORT ; sleep 3600`
     variables:
-        defines: variables
         db-addr:
             type: string
             value: <- get-hostname("mongodb/latest", "database")

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -16,7 +16,6 @@ namespace: foobars
 foo:
     defines: runnable
     containers:
-        defines: containers
         bar:
             image: alpine:latest
             entrypoint: <- `/bin/sh /root/r.sh`
@@ -24,14 +23,12 @@ foo:
                 container-started: hello-world
 
     files:
-        defines: files
         r1:
             path: /root/r.sh
             container: bar
             contents: "while true; do sleep 1; date; done"
 
     actions:
-        defines: actions
         hello-world:
             code: exec("bar", "/bin/sh", "-c", `echo "Hello World" > /tmp/hello`)
 ```

--- a/docs/k8s-migrate.md
+++ b/docs/k8s-migrate.md
@@ -71,7 +71,6 @@ namespace: /yelb
 ui:
     defines: runnable
     containers:
-        defines: containers
         yelb-ui:
             image-tag: "0.7"
             image: mreferre/yelb-ui
@@ -121,7 +120,6 @@ namespace: /yelb
 appserver:
     defines: runnable
     containers:
-        defines: containers
         yelb-appserver:
             image-tag: "0.5"
             image: mreferre/yelb-appserver
@@ -163,7 +161,6 @@ namespace: /yelb
 db:
     defines: runnable
     containers:
-        defines: containers
         yelb-db:
             image-tag: "0.5"
             image: mreferre/yelb-db
@@ -205,7 +202,6 @@ namespace: /yelb
 redis:
     defines: runnable
     containers:
-        defines: containers
         redis-server:
             image-tag: "4.0.2"
             image: redis
@@ -383,7 +379,6 @@ namespace: /yelb
 ui:
 defines: runnable
 containers:
-    defines: containers
     yelb-ui:
     image-tag: "0.7"
     image: mreferre/yelb-ui
@@ -470,7 +465,6 @@ namespace: /yelb
 ui:
 defines: runnable
 containers:
-    defines: containers
     yelb-ui:
     image-tag: "0.7"
     image: mreferre/yelb-ui
@@ -480,7 +474,6 @@ containers:
         /startup.sh`
 
 variables:
-    defines: variables
     port: 80
     yelb-appserver-addr:
     type: string
@@ -576,7 +569,6 @@ namespace: /yelb
 appserver:
     defines: runnable
     containers:
-        defines: containers
         yelb-appserver:
             image-tag: "0.5"
             image: mreferre/yelb-appserver
@@ -586,7 +578,6 @@ appserver:
                 /startup.sh`
 
     variables:
-        defines: variables
         port: 4567
         yelb-db-addr:
             type: string
@@ -753,14 +744,12 @@ appserver:
     # We are inheriting main runnable yelb/appserver
     inherits: yelb/appserver
     containers:
-        defines: containers
         # We will overwrite our image-tag here, all other definition of the runnable will stay the same
         yelb-appserver:
             image-tag: "0.4"
 
     # Update the namespace in our variables, changing it from yelb to yelb-production
     variables:
-        defines: variables
         yelb-db-addr:
             type: string
             value: <- get-hostname("yelb-production/db", "yelb-db")
@@ -779,7 +768,6 @@ ui:
     inherits: yelb/ui
 
     variables:
-        defines: variables
         # Update our appserver hostname here with production version
         yelb-appserver-addr:
             type: string
@@ -803,12 +791,10 @@ appserver:
     defines: runnable
     inherits: yelb/appserver
     containers:
-        defines: containers
         yelb-appserver:
             image-tag: "0.4"
 
     variables:
-        defines: variables
         yelb-db-addr:
             type: string
             value: <- get-hostname("yelb-production/db", "yelb-db")
@@ -822,7 +808,6 @@ ui:
     inherits: yelb/ui
 
     variables:
-        defines: variables
         yelb-appserver-addr:
             type: string
             value: <- get-hostname("yelb-production/appserver", "yelb-appserver")

--- a/docs/load-balancers.md
+++ b/docs/load-balancers.md
@@ -30,14 +30,12 @@ service-1:
     defines: runnable
     inherits: nginx/latest
     variables:
-        defines: variables
         listen-port: 8080
 
 service-2:
     defines: runnable
     inherits: nginx/latest
     variables:
-        defines: variables
         listen-port: 8080
 
 services:
@@ -66,7 +64,6 @@ services:
     defines: process-group
 
     balancers:
-        defines: balancers
         app-balancer:
             type: http
             port: 8080
@@ -102,7 +99,6 @@ services:
     defines: process-group
 
     balancers:
-        defines: balancers
         app-balancer:
             type: http
             domain: mystuff.com
@@ -158,7 +154,6 @@ services:
     defines: process-group
 
     balancers:
-        defines: balancers
         app-balancer:
             type: tcp
             port: 8080
@@ -188,7 +183,6 @@ services:
     defines: process-group
 
     balancers:
-        defines: balancers
         app-balancer:
             type: udp
             port: 8080
@@ -227,7 +221,6 @@ services:
     defines: process-group
 
     balancers:
-        defines: balancers
         app-balancer:
             type: elastic-ip
             instances:
@@ -254,7 +247,6 @@ services:
     defines: process-group
 
     balancers:
-        defines: balancers
         app-balancer:
             port: 8080
             type: http
@@ -284,7 +276,6 @@ services:
     defines: process-group
 
     balancers:
-        defines: balancers
         app-balancer:
             port: 8080
             type: http

--- a/docs/monkscript/scripting/index.md
+++ b/docs/monkscript/scripting/index.md
@@ -78,7 +78,6 @@ Will return `3` as long as it is placed within a [`runnable`](./yaml/runnables) 
 
 ```yaml
 variables:
-    defines: variables
     foo: 1
     bar: 2
 ```

--- a/docs/monkscript/yaml/groups.md
+++ b/docs/monkscript/yaml/groups.md
@@ -34,7 +34,6 @@ Runnable sections can have multiple sub-sections of special meaning. All definit
 
 ```yaml
 variables:
-    defines: variables
     variable-a: ...
     variable-b: ...
 ```
@@ -88,7 +87,6 @@ A variable can either just specify the value - in which case the type is inferre
 
 ```yaml
 variables:
-    defines: actions
     action-a: ...
     action-b: ...
 ```
@@ -146,7 +144,6 @@ Actions are somewhat akin to function definitions known from regular programming
 
 ```yaml linenums="1"
 actions:
-    defines: actions
 
     sum:
         description: sums two numbers
@@ -168,7 +165,6 @@ actions:
 
 ```yaml linenums="1"
 balancers:
-    defines: balancers
     balancer-a: ...
     balancer-b: ...
 ```

--- a/docs/monkscript/yaml/index.md
+++ b/docs/monkscript/yaml/index.md
@@ -121,12 +121,10 @@ Consider the following definitions:
 foo:
     defines: runnable
     containers:
-        defines: containers
         ...
 bar:
     defines: runnable
     fun-boxes:
-        defines: containers
 ```
 
 Both `foo` and `bar` are [`runnable`](#runnable). The key defines has special meaning, it labels its parent node with a _descriptor_ (in this case, `runnable`). Monk finds relevant sections by looking at those descriptors.

--- a/docs/monkscript/yaml/runnables.md
+++ b/docs/monkscript/yaml/runnables.md
@@ -13,7 +13,6 @@ example-runnable:
     defines: runnable
 
     containers:
-        defines: containers
         utils:
             image: amouat/network-utils
             image-tag: latest
@@ -30,7 +29,6 @@ Runnable sections can have multiple sub-sections of special meaning. All definit
 
 ```yaml
 containers:
-    defines: containers
     container-a: ...
     container-b: ...
 ```
@@ -86,7 +84,6 @@ container-name:
 
 ```yaml
 variables:
-    defines: variables
     variable-a: ...
     variable-b: ...
 ```
@@ -138,7 +135,6 @@ A variable can either just specify the value - in which case the type is inferre
 
 ```yaml
 variables:
-    defines: actions
     action-a: ...
     action-b: ...
 ```
@@ -196,7 +192,6 @@ Actions are somewhat akin to function definitions known from regular programming
 
 ```yaml linenums="1"
 actions:
-    defines: actions
 
     sum:
         description: sums two numbers
@@ -218,7 +213,6 @@ actions:
 
 ```yaml linenums="1"
 files:
-    defines: files
     file-a: ...
     file-b: ...
 ```
@@ -272,7 +266,6 @@ It's useful to declare multiline file `contents` using YAML syntax `|`
 
 ```yaml linenums="1"
 files:
-    defines: files
     poem:
         path: /var/poem.txt
         container: dummy
@@ -307,7 +300,6 @@ Each runnable can contain status checks. Currently the only supported check is `
 
 ```yaml linenums="1"
 checks:
-    defines: checks
     readiness:
         code: exec("ethereum-node", "echo", "-e", "two") "two" contains?
         period: 15
@@ -323,7 +315,6 @@ This works by awaiting the results of [`readiness` `checks`](#checks) on all ref
 
 ```yaml linenums="1"
 depends:
-    defines: depends
     wait-for:
         runnables:
             - /some/another-runnable
@@ -346,7 +337,6 @@ If it doesn't exist, Monk will assume default values:
 
 ```yaml linenums="1"
 recovery:
-    defines: recovery
     after: 60s # timeout before start recovey mechanism
     when: always/node-failure/container-failure/none # condition when to start recovery
     # node-failure - recover only if node is failed
@@ -375,7 +365,6 @@ If `ignore-pressure` is `true` (`false` by default) Monk will ignore pressure an
 
 ```yaml linenums="1"
 affinity:
-    defines: affinity
     tag: test-node
     name: test
     ignore-pressure: false

--- a/docs/monkscript/yaml/services.md
+++ b/docs/monkscript/yaml/services.md
@@ -15,7 +15,6 @@ example-service:
     defines: service
 
     variables:
-        defines: variables
         foo: 1
         bar: 2
 ```
@@ -30,7 +29,6 @@ Service sections can have multiple sub-sections of special meaning. All definiti
 
 ```yaml
 variables:
-    defines: variables
     variable-a: ...
     variable-b: ...
 ```
@@ -82,7 +80,6 @@ A variable can either just specify the value - in which case the type is inferre
 
 ```yaml
 variables:
-    defines: actions
     action-a: ...
     action-b: ...
 ```
@@ -140,7 +137,6 @@ Actions are somewhat akin to function definitions known from regular programming
 
 ```yaml linenums="1"
 actions:
-    defines: actions
 
     sum:
         description: sums two numbers

--- a/docs/passing-secrets.md
+++ b/docs/passing-secrets.md
@@ -58,7 +58,6 @@ namespace: mystuff
 my-service:
     defines: runnable
     containers:
-        defines: containers
         foo:
             image: foo:latest
             environment:

--- a/docs/persistent-storage.md
+++ b/docs/persistent-storage.md
@@ -39,7 +39,6 @@ database:
     defines: runnable
     inherits: mongodb/latest
     volumes:
-        defines: volumes
         important-data:
             size: 60
             kind: SSD
@@ -59,7 +58,6 @@ database:
     defines: runnable
     inherits: mongodb/latest
     volumes:
-        defines: volumes
         important-data:
             size: 60
             kind: SSD
@@ -70,7 +68,6 @@ We have just replaced the `${monk-volume-path}/mongodb` because `database` inher
 
 ```yaml title="mongodb/latest" linenums="1"
 containers:
-    defines: containers
     database:
         image: mongo:latest
         ports: 27017:27017
@@ -87,7 +84,6 @@ database:
     defines: runnable
     inherits: mongodb/latest
     volumes:
-        defines: volumes
         important-data:
             size: 60
             kind: SSD

--- a/docs/provisioning-via-templates.md
+++ b/docs/provisioning-via-templates.md
@@ -27,7 +27,6 @@ foo:
     defines: runnable
 
     nodes:
-        defines: nodes
         my-node:
             provider: gcp
             tag: my-magical-cluster
@@ -36,11 +35,9 @@ foo:
             disk-size: 128
 
     affinity:
-        defines: affinity
         name: my-node
 
     containers:
-        defines: containers
         some-service:
             image: some/image
             image-tag: latest

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -64,10 +64,8 @@ namespace: gizmotron
 
 common:
     metadata:
-        defines: metadata
         ...
     containers:
-        defines: containers
         app:
             image: docker.io/gizmotron
             ...
@@ -100,7 +98,6 @@ namespace: gizmotron
 foo:
     defines: runnable
     containers:
-        defines: containers
         app:
             ...
             environment:
@@ -115,7 +112,6 @@ complete-foo-setup:
         - postgres/latest
         - redis/latest
     variables:
-        defines: variables
         admin-username: change me
         admin-password: change me, for real
 ```
@@ -146,7 +142,6 @@ namespace: gizmotron
 common:
   ...
   metadata:
-    defines: metadata
     name: Gizmotron
     description: Open-source gizmotronic gizmo making gizmo that puts things on 🔥
     tags: comma, separated, list of tags
@@ -164,7 +159,6 @@ All metadata fields are optional and you can add any arbitrary field here, i.e.
 
 ```yaml
 metadata:
-    defines: metadata
     twitter: "@gizmotron"
     proprietary-gizmo-id: 42
 ```
@@ -290,7 +284,6 @@ namespace: gizmotron
 
 common:
     containers:
-        defines: containers
         app:
             image: docker.io/gizmotron
     ...
@@ -317,7 +310,6 @@ namespace: gizmotron
 
 common:
     containers:
-        defines: containers
         app:
             image: docker.io/gizmotron
     ...
@@ -369,7 +361,6 @@ namespace: gizmotron
 
 common:
     containers:
-        defines: containers
         app:
             image: docker.io/gizmotron
     ...

--- a/docs/readiness-and-dependency-checks.md
+++ b/docs/readiness-and-dependency-checks.md
@@ -43,7 +43,6 @@ namespace: readiness
 
 common:
     containers:
-        defines: containers
         fooc:
             image: alpine
             image-tag: latest
@@ -53,7 +52,6 @@ bar:
     defines: runnable
     inherits: ./common
     checks:
-        defines: checks
         readiness:
             code: |
                 exec("fooc", "ps", "-ef") "sleep" contains?
@@ -75,7 +73,6 @@ Lets have a look at full definition of dependency checks:
 
 ```yaml
 depends:
-    defines: depends
     wait-for:
         runnables:
             - <a runnable path to wait for>
@@ -92,7 +89,6 @@ namespace: readiness
 
 common:
     containers:
-        defines: containers
         foo:
             image: alpine
             image-tag: latest
@@ -103,7 +99,6 @@ bar:
     inherits: ./common
 
     checks:
-        defines: checks
         readiness:
             code: |
                 exec("foo", "ps", "-ef") contains?("sleep")
@@ -116,7 +111,6 @@ baz:
     inherits: ./common
 
     depends:
-        defines: depends
         wait-for:
             runnables:
                 - ./bar
@@ -133,7 +127,6 @@ We've added here our simple dependency using:
 
 ```yaml
 depends:
-    defines: depends
     wait-for:
         runnables:
             - ./bar


### PR DESCRIPTION
Removed deprecated `defines` for subsections from examples.