### PR TITLE
added proxy-target-host to HTTP load balancer example

### DIFF
--- a/_mkdocs/docs/guides/load-balancers.md
+++ b/_mkdocs/docs/guides/load-balancers.md
@@ -23,6 +23,7 @@ service-1:
     variables:
         defines: variables
         listen-port: 8080
+        proxy-target-host: www.exmple.com
 
 service-2:
     defines: runnable
@@ -30,6 +31,7 @@ service-2:
     variables:
         defines: variables
         listen-port: 8080
+        proxy-target-host: www.exmple.com
 
 services:
     defines: process-group

--- a/docs/load-balancers.md
+++ b/docs/load-balancers.md
@@ -32,6 +32,7 @@ service-1:
     variables:
         defines: variables
         listen-port: 8080
+        proxy-target-host: www.exmple.com
 
 service-2:
     defines: runnable
@@ -39,6 +40,7 @@ service-2:
     variables:
         defines: variables
         listen-port: 8080
+        proxy-target-host: www.exmple.com
 
 services:
     defines: process-group


### PR DESCRIPTION
added `proxy-target-host` to HTTP load balancer, because without it example LB starts but fails on attempt to access LB URL
```
namespace: /lbs

service-1:
    defines: runnable
    inherits: nginx/latest
    variables:
        defines: variables
        listen-port: 8080
        proxy-target-host: www.exmple.com
```