### PR TITLE
(chore) Put apt key in `trusted.gpg.d` dir

### DIFF
--- a/docs/get-monk.md
+++ b/docs/get-monk.md
@@ -44,7 +44,7 @@ We run an APT repository containing official releases of Monk. You can obtain th
 
 Add Monk repository to your sources list:
 
-    curl -s https://apt.monk.io/Release.gpg | sudo apt-key add -
+    curl -s https://apt.monk.io/Release.gpg | sudo tee /etc/apt/trusted.gpg.d/monk.asc
     sudo echo "deb [arch=amd64] https://apt.monk.io/ stable main" | sudo tee /etc/apt/sources.list.d/monk.list
     sudo apt update
 

--- a/docs/monk-in-10.md
+++ b/docs/monk-in-10.md
@@ -35,7 +35,7 @@ values={[
 
 <TabItem value="mainLinux">
 
-    curl -s https://apt.monk.io/Release.gpg | sudo apt-key add -
+    curl -s https://apt.monk.io/Release.gpg | sudo tee /etc/apt/trusted.gpg.d/monk.asc
     sudo echo "deb [arch=amd64] https://apt.monk.io/ stable main" | sudo tee /etc/apt/sources.list.d/monk.list
     sudo apt update
     sudo apt install monk


### PR DESCRIPTION
Putting keys in `/etc/apt/trusted.gpg` with `apt-key add` is deprecated,
instead they should be stored in their own files under
`/etc/apt/trusted.gpg.d`.